### PR TITLE
Fixed: Don't force download clang-3.8 on macOS

### DIFF
--- a/opam
+++ b/opam
@@ -5,10 +5,11 @@ homepage: "https://github.com/Antique-team/clangml"
 bug-reports: "https://github.com/Antique-team/clangml/issues"
 dev-repo: "https://github.com/Antique-team/clangml.git"
 build: [
-  ["wget" "http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz"] {os = "darwin"}
-  ["sh" "-c" "tar xJf clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz"] {os = "darwin"}
-  ["sh" "-c" "mkdir -p ${HOME}/usr/clang38"] {os = "darwin"}
-  ["sh" "-c" "mv clang+llvm-3.8.0-x86_64-apple-darwin/* ${HOME}/usr/clang38"] {os = "darwin"}
+  ["sh" "-c" "test -d ${HOME}/usr/clang38 \
+    || ( wget http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz \
+      && tar xJf clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz \
+      && mkdir -p ${HOME}/usr/clang38 \
+      && mv clang+llvm-3.8.0-x86_64-apple-darwin/* ${HOME}/usr/clang38 )"] {os = "darwin"}
   [make]
 ]
 install: [make "install"]


### PR DESCRIPTION
clang-3.8 is downloaded only if ~/usr/clang38 doesn't already exist.
Previously, if ~/usr/clang38 did already exist, the build failed on
the "mv" command.