### PR TITLE
Fix compilation with OCaml 4.06

### DIFF
--- a/tools/bridgen/bridgen.ml
+++ b/tools/bridgen/bridgen.ml
@@ -11,28 +11,29 @@ open Prelude
   This function is non-destructive (returns a new string).
  *)
 let cpp_name name =
+  let name = Bytes.of_string name in
   let rec to_camelcase length name =
     try
       (* If the name starts with an underscore,
          keep that first underscore. *)
-      let underscore = String.index_from name 1 '_' in
+      let underscore = Bytes.index_from name 1 '_' in
       (* If it ends with one, also keep that. *)
       if underscore = length - 1 then
         raise Not_found
       else (
-        String.blit
+        Bytes.blit
           name (underscore + 1)
           name underscore
           (length - underscore - 1);
-        Bytes.set name underscore (Char.uppercase name.[underscore]);
+        Bytes.set name underscore (Char.uppercase (Bytes.get name underscore));
         to_camelcase (length - 1) name
       )
     with Not_found ->
       (* Second copy here. *)
-      String.sub name 0 length
+      Bytes.to_string (Bytes.sub name 0 length)
   in
   (* First copy here. *)
-  to_camelcase (String.length name) (String.capitalize name)
+  to_camelcase (Bytes.length name) (Bytes.capitalize name)
 
 
 (*****************************************************

--- a/tools/simplify/toSimple.ml
+++ b/tools/simplify/toSimple.ml
@@ -175,7 +175,7 @@ let make_simplify_record_type env filtered_types rt =
            )
       in
 
-      <:expr<{ () with $rec_bindings$ }>>
+      <:expr<{ (assert false) with $rec_bindings$ }>>
   in
 
   <:binding<

--- a/tools/visitgen/generateVisitor.ml
+++ b/tools/visitgen/generateVisitor.ml
@@ -523,5 +523,5 @@ let codegen kind (visit_types : string list) ocaml_types =
     $tydcl$;;
 
     $functions$;;
-    let default = { () with $default$ };;
+    let default = { (assert false) with $default$ };;
   >>


### PR DESCRIPTION
Here is a pull request enabling compilation of Clangml with a 4.06 compiler.
I haven't been able to test the 4.07 beta because a compatible camlp4 version hasn't been released yet, but I will check whether it works when it's released.